### PR TITLE
Adding SSL redirect

### DIFF
--- a/backend/dashyserver/settings/prod.py
+++ b/backend/dashyserver/settings/prod.py
@@ -57,3 +57,8 @@ DATABASES = {
 DATABASE_URL = os.environ.get('DATABASE_URL')
 db_from_env = dj_database_url.config(default=DATABASE_URL, conn_max_age=500, ssl_require=True)
 DATABASES['default'].update(db_from_env)
+
+
+# SSL redirects
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
# Issue/Feature Request: #38

# Objective
Add SSL redirects to Django in order for allauth moule to generate https callbacks

# Changes
Add SSL redirects to Django


# Areas of Effect
- [x] Backend - Auth
- [ ] Backend - UI
- [ ] Backend - Data
- [ ] Backend - Other
- [ ] Frontend - UI
- [ ] Frontend - Auth
- [ ] Frontend - Data
- [ ] Frontend - User Flow
- [ ] Frontend - Other

# Testing
